### PR TITLE
Dockerfile: expose correct ports for swap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,8 +140,10 @@ VOLUME /root/.swap
 # swap-wallet-cli
 VOLUME /wallet
 
-EXPOSE 18080
-EXPOSE 18081
+EXPOSE 19949
+EXPOSE 19950
+EXPOSE 29949
+EXPOSE 29950
 
-ENTRYPOINT ["swapd", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=18080", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--non-interactive", "--confirm-external-bind"]
+ENTRYPOINT ["swapd", "--p2p-bind-ip=0.0.0.0", "--p2p-bind-port=19949", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=19950", "--non-interactive", "--confirm-external-bind"]
 


### PR DESCRIPTION
Add mainnet and testnet ports to be exposed.

Signed-off-by: Tyler Baker <tyler@foundries.io>