### PR TITLE
Pin Ubuntu runner version to 20.04

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build-ubuntu:
  
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
  
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This fixes issues with Boost versions